### PR TITLE
Be less intrusive overwriting Kernel#warn

### DIFF
--- a/lib/structured_warnings/kernel.rb
+++ b/lib/structured_warnings/kernel.rb
@@ -38,7 +38,6 @@ module StructuredWarnings
     #
     #   warn Warning.new("The least specific warning you can get")
     #
-    alias_method :old_warn, :warn
     def warn(*args)
       first = args.shift
       if first.is_a? Class and first <= Warning
@@ -54,7 +53,7 @@ module StructuredWarnings
         message = first.to_s
       end
 
-      old_warn(*args) unless args.empty?
+      super unless args.empty?
 
       if warning.active?
         output = StructuredWarnings.warner.format(warning, message, caller(1))

--- a/lib/structured_warnings/kernel.rb
+++ b/lib/structured_warnings/kernel.rb
@@ -38,6 +38,7 @@ module StructuredWarnings
     #
     #   warn Warning.new("The least specific warning you can get")
     #
+    alias_method :old_warn, :warn
     def warn(*args)
       first = args.shift
       if first.is_a? Class and first <= Warning
@@ -53,10 +54,7 @@ module StructuredWarnings
         message = first.to_s
       end
 
-      unless args.empty?
-        raise ArgumentError,
-              "wrong number of arguments (#{args.size + 2} for 2)"
-      end
+      old_warn(*args) unless args.empty?
 
       if warning.active?
         output = StructuredWarnings.warner.format(warning, message, caller(1))

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -6,6 +6,11 @@ class Foo
     warn DeprecatedMethodWarning,
          'This method is deprecated. Use new_method instead'
   end
+
+  def old_method_too
+    warn :deprecated,
+        'This method is deprecated. Use new_method instead'
+  end
 end
 
 class StructuredWarningsTest < Test::Unit::TestCase
@@ -30,6 +35,12 @@ class StructuredWarningsTest < Test::Unit::TestCase
   def test_warn
     assert_warn(DeprecatedMethodWarning) do
       Foo.new.old_method
+    end
+  end
+
+  def test_old_warn
+    assert_warn(:deprecated) do
+      Foo.new.old_method_too
     end
   end
 


### PR DESCRIPTION
Overwriting Kernel#warn is incompatible with many existing libraries. This pr amends that by calling the overwritten method if we don't receive the arguments we are looking for.