### PR TITLE
Migrate to GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.4', '2.5', '2.6', '2.7']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
----
-language: ruby
-sudo: false
-rvm:
-  - 2.7.0
-  - 2.6.5
-  - 2.5.7
-  - 2.4.8

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ give as much feedback to your users as possible.
 * [Implementation Highlights](http://www.nach-vorne.de/2008/2/22/structured_warnings-highlights)
 * [Project's website](https://github.com/schmidt/structured_warnings/)
 * [API doc](http://rdoc.info/projects/schmidt/structured_warnings)
-* [Build status](https://travis-ci.org/schmidt/structured_warnings)
+* [Build status](https://github.com/schmidt/structured_warnings/actions)
 
 
 ## Development


### PR DESCRIPTION
Because travis-ci is conceptually dead and GitHub actions is here to stay.