### PR TITLE
Update to latest stable ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7']
+        ruby-version: ['2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.14.0)
-    power_assert (1.1.6)
-    rake (13.0.1)
-    test-unit (3.3.5)
+    minitest (5.16.3)
+    power_assert (2.0.1)
+    rake (13.0.6)
+    test-unit (3.5.5)
       power_assert
 
 PLATFORMS
@@ -23,4 +23,4 @@ DEPENDENCIES
   test-unit (~> 3.0)
 
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -131,8 +131,14 @@ class StructuredWarningsTest < Test::Unit::TestCase
     return unless supports_core_warnings?
 
     with_verbose_warnings do
-      assert_warn(StructuredWarnings::BuiltInWarning, /instance variable @ivar not initialized/) do
-        Object.new.instance_variable_get(:@ivar)
+      assert_warn(StructuredWarnings::BuiltInWarning, /method redefined; discarding old name/) do
+        class << Object.new
+          attr_accessor :name
+
+          def name
+            @name.to_s.downcase
+          end
+        end
       end
     end
   end
@@ -244,13 +250,19 @@ class StructuredWarningsTest < Test::Unit::TestCase
     return unless supports_core_warnings?
 
     actual_warning = capture_strderr do
-      Object.new.instance_variable_get(:@ivar)
+      class << Object.new
+        attr_accessor :name
+
+        def name
+          @name.to_s.downcase
+        end
+      end
     end
 
     expected_warning =
-      "#{__FILE__}:#{__LINE__ - 4}:" +
-      "in `instance_variable_get': " +
-      "instance variable @ivar not initialized " +
+      "#{__FILE__}:#{__LINE__ - 7}:" +
+      "in `singleton class': " +
+      "method redefined; discarding old name " +
       "(StructuredWarnings::BuiltInWarning)\n"
 
     assert_equal expected_warning, actual_warning


### PR DESCRIPTION
This change removes unmaintained Ruby versions from CI and adds "newly" released Ruby versions instead.

I had to change the test, because the instance var related warning [was removed in 3.0](https://bugs.ruby-lang.org/issues/17055). I am now using the slightly more verbose method redefinition warning now.

Also updating gems that are used in CI to be make them work with newer Rubies