### PR TITLE
Improve compatibility with newer Rubies

### DIFF
--- a/lib/structured_warnings/kernel.rb
+++ b/lib/structured_warnings/kernel.rb
@@ -1,6 +1,6 @@
 module StructuredWarnings::Kernel
-  def warn(*args)
-    Warning.warn(*args)
+  def warn(*args, **opts)
+    Warning.warn(*args, **opts)
   end
 end
 

--- a/lib/structured_warnings/warning.rb
+++ b/lib/structured_warnings/warning.rb
@@ -52,7 +52,7 @@ module StructuredWarnings::Warning
 
     else
       warning = StructuredWarnings::BuiltInWarning
-      message = first.to_s.split(':', 4).last[1..-2]
+      message = first.to_s.split(':', 4).last.strip
     end
 
     # If args is not empty, user passed an incompatible set of arguments.

--- a/lib/structured_warnings/warning.rb
+++ b/lib/structured_warnings/warning.rb
@@ -36,7 +36,7 @@ module StructuredWarnings::Warning
   #
   #   warn StructuredWarnings::Base.new("The least specific warning you can get")
   #
-  def warn(*args)
+  def warn(*args, **options)
     first = args.shift
     if first.is_a? Class and first <= StructuredWarnings::Base
       warning = first
@@ -54,8 +54,6 @@ module StructuredWarnings::Warning
       warning = StructuredWarnings::BuiltInWarning
       message = first.to_s.split(':', 4).last[1..-2]
     end
-
-    options = args.first.is_a?(Hash) ? args.shift : {}
 
     # If args is not empty, user passed an incompatible set of arguments.
     # Maybe somebody else is overriding warn as well and knows, what to do.

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -211,11 +211,14 @@ class StructuredWarningsTest < Test::Unit::TestCase
       warn 'do not blink'
     end
 
-    expected_warning =
-      "#{__FILE__}:#{__LINE__ - 4}:" +
-      "in `block in test_formatting_of_warn': " +
-      "do not blink " +
-      "(StructuredWarnings::StandardWarning)\n"
+    expected_warning = "#{__FILE__}:#{__LINE__ - 3}:"
+    expected_warning += if RUBY_VERSION >= '3.4'
+                          "in 'block in StructuredWarningsTest#test_formatting_of_warn': "
+                        else
+                          "in `block in test_formatting_of_warn': "
+                        end
+
+    expected_warning += "do not blink (StructuredWarnings::StandardWarning)\n"
 
     assert_equal expected_warning, actual_warning
   end
@@ -235,6 +238,8 @@ class StructuredWarningsTest < Test::Unit::TestCase
     expected_warning +=
       if RUBY_VERSION < '2.3'
         "in `call': "
+      elsif RUBY_VERSION >= '3.4'
+        "in 'block in StructuredWarningsTest#test_formatting_of_warn_with_uplevel': "
       else
         "in `block in test_formatting_of_warn_with_uplevel': "
       end
@@ -259,10 +264,14 @@ class StructuredWarningsTest < Test::Unit::TestCase
       end
     end
 
-    expected_warning =
-      "#{__FILE__}:#{__LINE__ - 7}:" +
-      "in `singleton class': " +
-      "method redefined; discarding old name " +
+    expected_warning = "#{__FILE__}:#{__LINE__ - 6}:"
+    expected_warning += if RUBY_VERSION >= '3.4'
+                          "in 'singleton class': "
+                        else
+                          "in `singleton class': "
+                        end
+
+    expected_warning += "method redefined; discarding old name " +
       "(StructuredWarnings::BuiltInWarning)\n"
 
     assert_equal expected_warning, actual_warning
@@ -275,10 +284,14 @@ class StructuredWarningsTest < Test::Unit::TestCase
       Warning.warn("This is a test warning.")
     end
 
-    expected_warning =
-      "#{__FILE__}:#{__LINE__ - 4}:" +
-      "in `block in test_formatting_of_manual_warn': " +
-      "This is a test warning. " +
+    expected_warning = "#{__FILE__}:#{__LINE__ - 3}:"
+    expected_warning += if RUBY_VERSION >= '3.4'
+                          "in 'block in StructuredWarningsTest#test_formatting_of_manual_warn': "
+                        else
+                          "in `block in test_formatting_of_manual_warn': "
+                        end
+
+    expected_warning += "This is a test warning. " +
       "(StructuredWarnings::BuiltInWarning)\n"
 
     assert_equal expected_warning, actual_warning

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -268,6 +268,22 @@ class StructuredWarningsTest < Test::Unit::TestCase
     assert_equal expected_warning, actual_warning
   end
 
+  def test_formatting_of_manual_warn
+    return unless supports_core_warnings?
+
+    actual_warning = capture_strderr do
+      Warning.warn("This is a test warning.")
+    end
+
+    expected_warning =
+      "#{__FILE__}:#{__LINE__ - 4}:" +
+      "in `block in test_formatting_of_manual_warn': " +
+      "This is a test warning. " +
+      "(StructuredWarnings::BuiltInWarning)\n"
+
+    assert_equal expected_warning, actual_warning
+  end
+
   protected
 
   def supports_fork?


### PR DESCRIPTION
In old Ruby versions named parameters were just a fancy way to append a hash to the list of positional arguments. Newer Ruby versions treat named parameters as something more special and they are not forwarded by `*args` anymore.

## Further reading

It's probably worth noting that the official docs also suggest forwarding additional keyword arguments blindly when overwriting the method: https://docs.ruby-lang.org/en/master/Warning.html