### PR TITLE
Update Rubys and Gems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1']
+        ruby-version: ['3.2', '3.3', '3.4']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,10 +6,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.16.3)
-    power_assert (2.0.1)
-    rake (13.0.6)
-    test-unit (3.5.5)
+    minitest (5.25.5)
+    power_assert (2.0.5)
+    rake (13.2.1)
+    test-unit (3.6.8)
       power_assert
 
 PLATFORMS
@@ -23,4 +23,4 @@ DEPENDENCIES
   test-unit (~> 3.0)
 
 BUNDLED WITH
-   2.3.7
+   2.6.2

--- a/README.md
+++ b/README.md
@@ -33,24 +33,9 @@ Or install it yourself as:
 
 ## Compatibility
 
-`structured_warnings` aims to work with all Ruby interpreters. Please file a bug
-for any incompatibilities.
-
-
-Versions of `structured_warnings` before `v0.3.0` are incompatible with Ruby
-2.4+. Please upgrade accordingly, if you need Ruby 2.4 compatibility. Please
-note on the otherhand, that many class names changed in an incompatible way
-with `structured_warnings` `v0.3.0`. This was done to avoid future name clashes.
-
-Here's a table which should ease upgrading.
-
-| v0.2.0 and before            | v0.3.0 and after                                 |
-|------------------------------|--------------------------------------------------|
-| `Warning`                    | `StructuredWarnings::Base`                       |
-| `StandardWarning`            | `StructuredWarnings::StandardWarning`            |
-| `DeprecationWarning`         | `StructuredWarnings::DeprecationWarning`         |
-| `DeprecatedMethodWarning`    | `StructuredWarnings::DeprecatedMethodWarning`    |
-| `DeprecatedSignatureWarning` | `StructuredWarnings::DeprecatedSignatureWarning` |
+`structured_warnings` aims to work with all stable, maintained Ruby versions. At
+the time of this writing this is Ruby 3.2, 3.3, and 3.4. Please file a bug for
+any incompatibilities.
 
 
 ### Test framework support

--- a/lib/structured_warnings.rb
+++ b/lib/structured_warnings.rb
@@ -1,8 +1,5 @@
 require 'structured_warnings/version'
 
-# Compatibility layer
-require 'warning' unless defined? ::Warning
-
 require 'dynamic'
 
 module StructuredWarnings

--- a/lib/structured_warnings/kernel.rb
+++ b/lib/structured_warnings/kernel.rb
@@ -1,6 +1,6 @@
 module StructuredWarnings::Kernel
-  def warn(*args)
-    Warning.warn(*args)
+  def warn(*args, **opts)
+    Warning.warn(*args, **opts)
   end
 end
 

--- a/lib/structured_warnings/warning.rb
+++ b/lib/structured_warnings/warning.rb
@@ -52,7 +52,7 @@ module StructuredWarnings::Warning
 
     else
       warning = StructuredWarnings::BuiltInWarning
-      message = first.to_s.split(':', 4).last[1..-2]
+      message = first.to_s.split(':', 4).last.strip
     end
 
     # If args is not empty, user passed an incompatible set of arguments.

--- a/lib/structured_warnings/warning.rb
+++ b/lib/structured_warnings/warning.rb
@@ -36,7 +36,7 @@ module StructuredWarnings::Warning
   #
   #   warn StructuredWarnings::Base.new("The least specific warning you can get")
   #
-  def warn(*args)
+  def warn(*args, **options)
     first = args.shift
     if first.is_a? Class and first <= StructuredWarnings::Base
       warning = first
@@ -54,8 +54,6 @@ module StructuredWarnings::Warning
       warning = StructuredWarnings::BuiltInWarning
       message = first.to_s.split(':', 4).last[1..-2]
     end
-
-    options = args.first.is_a?(Hash) ? args.shift : {}
 
     # If args is not empty, user passed an incompatible set of arguments.
     # Maybe somebody else is overriding warn as well and knows, what to do.

--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -1,9 +1,0 @@
-module Warning
-  KERNEL_WARN = Kernel.instance_method(:warn).bind(self)
-
-  def warn(*args)
-    KERNEL_WARN.call(*args)
-  end
-
-  extend self
-end

--- a/structured_warnings.gemspec
+++ b/structured_warnings.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 3.2.0'
+
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -144,8 +144,6 @@ class StructuredWarningsTest < Test::Unit::TestCase
   end
 
   def test_builtin_warnings
-    return unless supports_core_warnings?
-
     with_verbose_warnings do
       assert_warn(StructuredWarnings::BuiltInWarning, /method redefined; discarding old name/) do
         class << Object.new
@@ -255,8 +253,6 @@ class StructuredWarningsTest < Test::Unit::TestCase
   end
 
   def test_formatting_of_builtin_warn
-    return unless supports_core_warnings?
-
     actual_warning = capture_strderr do
       class << Object.new
         attr_accessor :name
@@ -286,10 +282,6 @@ class StructuredWarningsTest < Test::Unit::TestCase
     true
   rescue NotImplementedError
     false
-  end
-
-  def supports_core_warnings?
-    Warning.instance_method(:warn).source_location.nil?
   end
 
   def with_verbose_warnings

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -272,6 +272,20 @@ class StructuredWarningsTest < Test::Unit::TestCase
     assert_equal expected_warning, actual_warning
   end
 
+  def test_formatting_of_manual_warn
+    actual_warning = capture_strderr do
+      Warning.warn("This is a test warning.")
+    end
+
+    expected_warning =
+      "#{__FILE__}:#{__LINE__ - 4}:" +
+      "in #{opening_quote}block in #{classname_in_message}test_formatting_of_manual_warn': " +
+      "This is a test warning. " +
+      "(StructuredWarnings::BuiltInWarning)\n"
+
+    assert_equal expected_warning, actual_warning
+  end
+
   protected
 
   def supports_fork?

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -25,6 +25,22 @@ class StructuredWarningsTest < Test::Unit::TestCase
     end
   end
 
+  def opening_quote
+    if RUBY_VERSION < '3.4'
+      '`'
+    else
+      "'"
+    end
+  end
+
+  def classname_in_message
+    if RUBY_VERSION < '3.4'
+      ''
+    else
+      'StructuredWarningsTest#'
+    end
+  end
+
   def test_fork_in_thread
     return unless supports_fork?
 
@@ -213,7 +229,7 @@ class StructuredWarningsTest < Test::Unit::TestCase
 
     expected_warning =
       "#{__FILE__}:#{__LINE__ - 4}:" +
-      "in 'block in StructuredWarningsTest#test_formatting_of_warn': " +
+      "in #{opening_quote}block in #{classname_in_message}test_formatting_of_warn': " +
       "do not blink " +
       "(StructuredWarnings::StandardWarning)\n"
 
@@ -236,7 +252,7 @@ class StructuredWarningsTest < Test::Unit::TestCase
       if RUBY_VERSION < '2.3'
         "in `call': "
       else
-        "in 'block in StructuredWarningsTest#test_formatting_of_warn_with_uplevel': "
+        "in #{opening_quote}block in #{classname_in_message}test_formatting_of_warn_with_uplevel': "
       end
 
     expected_warning +=
@@ -261,7 +277,7 @@ class StructuredWarningsTest < Test::Unit::TestCase
 
     expected_warning =
       "#{__FILE__}:#{__LINE__ - 7}:" +
-      "in 'singleton class': " +
+      "in #{opening_quote}singleton class': " +
       "method redefined; discarding old name " +
       "(StructuredWarnings::BuiltInWarning)\n"
 

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -246,16 +246,8 @@ class StructuredWarningsTest < Test::Unit::TestCase
     end
 
     expected_warning =
-      "#{__FILE__}:#{__LINE__ - 4}:"
-
-    expected_warning +=
-      if RUBY_VERSION < '2.3'
-        "in `call': "
-      else
-        "in #{opening_quote}block in #{classname_in_message}test_formatting_of_warn_with_uplevel': "
-      end
-
-    expected_warning +=
+      "#{__FILE__}:#{__LINE__ - 4}:" +
+      "in #{opening_quote}block in #{classname_in_message}test_formatting_of_warn_with_uplevel': " +
       "do not blink " +
       "(StructuredWarnings::StandardWarning)\n"
 

--- a/test/structured_warnings_test.rb
+++ b/test/structured_warnings_test.rb
@@ -213,7 +213,7 @@ class StructuredWarningsTest < Test::Unit::TestCase
 
     expected_warning =
       "#{__FILE__}:#{__LINE__ - 4}:" +
-      "in `block in test_formatting_of_warn': " +
+      "in 'block in StructuredWarningsTest#test_formatting_of_warn': " +
       "do not blink " +
       "(StructuredWarnings::StandardWarning)\n"
 
@@ -236,7 +236,7 @@ class StructuredWarningsTest < Test::Unit::TestCase
       if RUBY_VERSION < '2.3'
         "in `call': "
       else
-        "in `block in test_formatting_of_warn_with_uplevel': "
+        "in 'block in StructuredWarningsTest#test_formatting_of_warn_with_uplevel': "
       end
 
     expected_warning +=
@@ -261,7 +261,7 @@ class StructuredWarningsTest < Test::Unit::TestCase
 
     expected_warning =
       "#{__FILE__}:#{__LINE__ - 7}:" +
-      "in `singleton class': " +
+      "in 'singleton class': " +
       "method redefined; discarding old name " +
       "(StructuredWarnings::BuiltInWarning)\n"
 


### PR DESCRIPTION
Update required Rubys to a maintained version. If anybody wants to use an older version of Ruby, they'll have to use an older version of structured warnings.

Cleaning up and removing older compatibility layers.

Also adding @NobodysNightmare's changes from #19 to improve cooperation with other gems overriding the default warning behavior.